### PR TITLE
Reduce Celery worker memory usage

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -61,7 +61,7 @@ case "$1" in
     setup_permissions
 
     # Run Celery as "$GUTENBERG_USERNAME"
-    runuser -u "$GUTENBERG_USERNAME" -- env UV_CACHE_DIR=/app/.cache/uv uv run celery -A gutenberg worker -l INFO
+    runuser -u "$GUTENBERG_USERNAME" -- env UV_CACHE_DIR=/app/.cache/uv uv run celery -A gutenberg worker -P threads -l INFO
     ;;
  *)
     echo "Error: Missing or invalid first argument to docker-entrypoint.sh: '$1'."


### PR DESCRIPTION
Change the Celery worker pool mode from `prefork` to `threads` to reduce RAM usage.
See https://docs.celeryq.dev/en/stable/userguide/concurrency/index.html