### PR TITLE
Fix mdbook builds by removing `mdbook-alerts` dependency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,6 @@ jobs:
         run: >
           cargo binstall -y
           mdbook
-          mdbook-alerts
           mdbook-mermaid
 
       - name: Build book

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /app/docs
 RUN apk add curl
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | sh
 
-RUN cargo binstall mdbook mdbook-mermaid mdbook-alerts
+RUN cargo binstall mdbook@0.5.2 mdbook-mermaid@0.17.0
 
 COPY ./docs /app/docs/
 RUN mdbook build

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -6,8 +6,6 @@ title = "Gutenberg documentation"
 [build]
 build-dir = "book"
 
-[preprocessor.alerts]
-
 [preprocessor.mermaid]
 command = "mdbook-mermaid"
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -22,6 +22,5 @@ in the `docs` directory.
 The book has been created using [mdBook](https://rust-lang.github.io/mdBook/index.html).
 These mdBook plugins are also installed:
 - [`mdbook-mermaid`](https://github.com/badboy/mdbook-mermaid)
-- [`mdbook-alerts`](https://github.com/lambdalisue/rs-mdbook-alerts)
 
 To contribute, fork this repository and create a pull request with your changes.


### PR DESCRIPTION
Fixes #146 by removing no longer necessary dependency on https://github.com/lambdalisue/rs-mdbook-alerts and specifying dependency versions to prevent build failures in the future