### PR TITLE
Fix ImageMagick use and tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,12 @@ jobs:
       with:
         version: "0.8.2"
 
+    - name: Install ImageMagick
+      uses: mfinelli/setup-imagemagick@v8
+      with:
+        cache: true
+        install-libfuse2: true
+
     - name: Configure venv and install dependencies
       working-directory: backend
       run: uv sync

--- a/backend/printing/processing/converter.py
+++ b/backend/printing/processing/converter.py
@@ -1,12 +1,11 @@
+import magic
 import os
 import shutil
 import subprocess
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List
-
-import magic
 from pypdf import PdfReader
+from typing import List
 
 from printing.processing.pages import PageSize, PageOrientation
 from printing.utils import SANDBOX_PATH, TASK_TIMEOUT_S, logger
@@ -148,7 +147,7 @@ class ImageConverter(SandboxConverter):
         # TODO: Use scaling options (like fit to page)
         self.run_in_sandbox(
             [
-                'convert', preprocess_result.preprocess_result_path,
+                'magick', preprocess_result.preprocess_result_path,
                 # Auto-orient the image based on the EXIF orientation tag
                 '-auto-orient',
                 # Resize the image to fit the "fit area"
@@ -165,7 +164,7 @@ class ImageConverter(SandboxConverter):
 
     @classmethod
     def is_available(cls):
-        return cls.binary_exists('convert')
+        return cls.binary_exists('magick')
 
 
 class DocConverter(EarlyConverter):

--- a/backend/printing/tests/printing/processing/test_converter.py
+++ b/backend/printing/tests/printing/processing/test_converter.py
@@ -221,7 +221,7 @@ class TestImageConverter:
         assert result.orientation == PageOrientation.PORTRAIT
 
     @patch.object(ImageConverter, 'run_in_sandbox')
-    def test_pdf_creation_calls_imagemagick_convert(
+    def test_pdf_creation_calls_magick(
         self, mock_run, work_dir, sample_page_size
     ):
         """PDF creation uses ImageMagick convert with correct parameters."""
@@ -235,7 +235,12 @@ class TestImageConverter:
 
         assert mock_run.called
         call_args = mock_run.call_args[0][0]
-        assert 'convert' in call_args
+
+        # `convert` is deprecated since ImageMagick 7,
+        # `magick` should be used instead
+        assert 'convert' not in call_args
+        assert 'magick' in call_args
+
         assert '-auto-orient' in call_args
         assert '-resize' in call_args
         assert result == os.path.join(work_dir, 'converted.pdf')

--- a/docs/src/admin/setup.md
+++ b/docs/src/admin/setup.md
@@ -9,7 +9,7 @@
 - Linux server: test `lp` command
 - Check if you have the following commands available:
   - `libreoffice` for printing .docx and .odt. A no-GUI version is enough,
-  - `convert` (package `imagemagick`) for printing image files,
+  - `magick` (package `imagemagick`) for printing image files,
   - `gs` (package `ghostscript`),
   - `bbwrap` (package `bubblewrap`).
   


### PR DESCRIPTION
1. Install ImageMagick in the GitHub Actions `test_django` job
2. Replace calls to `convert` with calls to `magick`. `convert` was deprecated in ImageMagick 7