### PR TITLE
Prebuilt docker images with Github Actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ on:
 # Use GitHub Container Registry
 env:
   REGISTRY: ghcr.io
-  # github.repository is usually owner/repo (e.g., ksiuj/gutenberg)
+  # github.repository is usually owner/repo (e.g., KSIUJ/gutenberg)
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -48,7 +48,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # For example, ghcr.io/ksiuj/gutenberg-backend
+          # For example, ghcr.io/KSIUJ/gutenberg-backend
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.suffix }}
           tags: |
             type=ref,event=branch

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,64 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  release:
+    types: [published]
+
+# Use GitHub Container Registry
+env:
+  REGISTRY: ghcr.io
+  # github.repository is usually owner/repo (e.g., ksiuj/gutenberg)
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required to push images to GHCR
+      packages: write
+
+    strategy:
+      # Map Dockerfile targets to final image name suffixes
+      matrix:
+        include:
+          - target: run_backend
+            suffix: -backend
+          - target: run_celery
+            suffix: -celery
+          - target: run_nginx
+            suffix: -proxy
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # For example, ghcr.io/ksiuj/gutenberg-backend
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.suffix }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: ${{ matrix.target }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,8 +11,8 @@ on:
 # Use GitHub Container Registry
 env:
   REGISTRY: ghcr.io
-  # github.repository is usually owner/repo (e.g., KSIUJ/gutenberg), converted to lowercase for GHCR compatibility
-  IMAGE_NAME: ${{ toLowerCase(github.repository) }}
+  # The prefix of all image names. Converted to lowercase for GHCR compatibility.
+  IMAGE_NAME: "ksiuj/gutenberg"
 
 jobs:
   build-and-push:
@@ -48,7 +48,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # For example, ghcr.io/KSIUJ/gutenberg-backend
+          # For example, ghcr.io/ksiuj/gutenberg-backend
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.suffix }}
           tags: |
             type=ref,event=branch

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,8 +11,8 @@ on:
 # Use GitHub Container Registry
 env:
   REGISTRY: ghcr.io
-  # github.repository is usually owner/repo (e.g., KSIUJ/gutenberg)
-  IMAGE_NAME: ${{ github.repository }}
+  # github.repository is usually owner/repo (e.g., KSIUJ/gutenberg), converted to lowercase for GHCR compatibility
+  IMAGE_NAME: ${{ toLowerCase(github.repository) }}
 
 jobs:
   build-and-push:

--- a/backend/gutenberg/settings/docker_server_overrides.py
+++ b/backend/gutenberg/settings/docker_server_overrides.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     raise ImportError(
         'The "docker_settings.py" file was not found. '
-        'Please create it based on "backend/gutenberg/settings/docker_settings.py.example" '
+        'Please download the initial configuration (e.g. from the Gutenberg repository) '
         'and mount it at "/etc/gutenberg/docker_settings.py". '
         'Check Gutenberg\'s documentation for more details.'
     )

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -27,13 +27,16 @@ services:
     restart: unless-stopped
 
   backend:
-    image: ghcr.io/ksiuj/gutenberg-backend:${GUTENBERG_VERSION:-main}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: run_backend
     container_name: gutenberg-backend
     volumes:
       - gutenberg_backend_logs:/var/log/gutenberg
       - gutenberg_backend_data:/var/lib/gutenberg
       - type: bind
-        source: ./docker_settings.py
+        source: ./backend/gutenberg/settings/docker_settings.py
         target: /etc/gutenberg/docker_settings.py
         read_only: true
       - type: bind
@@ -50,7 +53,10 @@ services:
       - gutenberg_django_secret_key
 
   celery:
-    image: ghcr.io/ksiuj/gutenberg-celery:${GUTENBERG_VERSION:-main}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: run_celery
     container_name: gutenberg-celery
     depends_on:
       db:
@@ -61,7 +67,7 @@ services:
       - gutenberg_backend_logs:/var/log/gutenberg
       - gutenberg_backend_data:/var/lib/gutenberg
       - type: bind
-        source: ./docker_settings.py
+        source: ./backend/gutenberg/settings/docker_settings.py
         target: /etc/gutenberg/docker_settings.py
         read_only: true
       - type: bind
@@ -84,7 +90,10 @@ services:
     privileged: true
 
   proxy:
-    image: ghcr.io/ksiuj/gutenberg-proxy:${GUTENBERG_VERSION:-main}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: run_nginx
     container_name: gutenberg-proxy
     ports:
       - "3000:80"
@@ -106,4 +115,3 @@ secrets:
     file: ./secrets/postgres_password.txt
   gutenberg_django_secret_key:
     file: ./secrets/django_secret_key.txt
-

--- a/compose.yml
+++ b/compose.yml
@@ -27,7 +27,7 @@ services:
     restart: unless-stopped
 
   backend:
-    image: ghcr.io/ksiuj/gutenberg-backend:${GUTENBERG_VERSION:-main}
+    image: ghcr.io/ksiuj/gutenberg-backend:${GUTENBERG_VERSION}
     container_name: gutenberg-backend
     volumes:
       - gutenberg_backend_logs:/var/log/gutenberg

--- a/compose.yml
+++ b/compose.yml
@@ -10,7 +10,6 @@ services:
       - gutenberg_postgres_data:/var/lib/postgresql/data
     restart: unless-stopped
     healthcheck:
-      # Replace the values of -U and -d with the name of the user and database if changed.
       test: [ "CMD-SHELL", "pg_isready -U gutenberg -d gutenberg" ]
       interval: 1s
       retries: 10
@@ -18,25 +17,21 @@ services:
     secrets:
       - gutenberg_postgres_password
 
-  # SECURITY: The Redis image does not enable authentication by default.
-  # This container should not be exposed to the internet, it should only be accessible
-  # in the internal Docker-managed network.
   redis:
     image: redis:8.2-alpine3.22
     container_name: gutenberg-redis
     restart: unless-stopped
 
   backend:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: run_backend
+    # Use published image instead of building from source
+    image: ghcr.io/ksiuj/gutenberg-backend:main
     container_name: gutenberg-backend
     volumes:
       - gutenberg_backend_logs:/var/log/gutenberg
       - gutenberg_backend_data:/var/lib/gutenberg
+      # Expect docker_settings.py to be in the same directory as compose.yml
       - type: bind
-        source: ./backend/gutenberg/settings/docker_settings.py
+        source: ./docker_settings.py
         target: /etc/gutenberg/docker_settings.py
         read_only: true
       - type: bind
@@ -53,10 +48,8 @@ services:
       - gutenberg_django_secret_key
 
   celery:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: run_celery
+    # Use published image instead of building from source
+    image: ghcr.io/ksiuj/gutenberg-celery:main
     container_name: gutenberg-celery
     depends_on:
       db:
@@ -66,8 +59,9 @@ services:
     volumes:
       - gutenberg_backend_logs:/var/log/gutenberg
       - gutenberg_backend_data:/var/lib/gutenberg
+      # Expect docker_settings.py to be in the same directory as compose.yml
       - type: bind
-        source: ./backend/gutenberg/settings/docker_settings.py
+        source: ./docker_settings.py
         target: /etc/gutenberg/docker_settings.py
         read_only: true
       - type: bind
@@ -77,23 +71,13 @@ services:
     secrets:
       - gutenberg_postgres_password
       - gutenberg_django_secret_key
-
-    # The cap_add SYS_ADMIN and privileged settings allow bubblewrap to run inside the container.
-    # The security implications of these changes have not been properly reviewed.
-    # FIXME: These settings should probably me more restrictive.
-    #
-    # Some relevant links:
-    # - https://docs.docker.com/engine/security/apparmor/
-    # - https://docs.docker.com/engine/security/seccomp/
     cap_add:
       - SYS_ADMIN
     privileged: true
 
   proxy:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: run_nginx
+    # Use published image instead of building from source
+    image: ghcr.io/ksiuj/gutenberg-proxy:main
     container_name: gutenberg-proxy
     ports:
       - "3000:80"
@@ -106,10 +90,6 @@ volumes:
   gutenberg_backend_logs:
   gutenberg_backend_data:
 
-# Docker Compose only supports loading secrets from files or environment variables
-# https://docs.docker.com/reference/compose-file/secrets/
-# These secrets should be randomly generated, for example, using commands like:
-#   openssl rand -base64 32 > ./secrets/postgres_password.txt
 secrets:
   gutenberg_postgres_password:
     file: ./secrets/postgres_password.txt

--- a/compose.yml
+++ b/compose.yml
@@ -84,7 +84,7 @@ services:
     privileged: true
 
   proxy:
-    image: ghcr.io/ksiuj/gutenberg-proxy:${GUTENBERG_VERSION:-main}
+    image: ghcr.io/ksiuj/gutenberg-proxy:${GUTENBERG_VERSION}
     container_name: gutenberg-proxy
     ports:
       - "3000:80"

--- a/compose.yml
+++ b/compose.yml
@@ -50,7 +50,7 @@ services:
       - gutenberg_django_secret_key
 
   celery:
-    image: ghcr.io/ksiuj/gutenberg-celery:${GUTENBERG_VERSION:-main}
+    image: ghcr.io/ksiuj/gutenberg-celery:${GUTENBERG_VERSION}
     container_name: gutenberg-celery
     depends_on:
       db:

--- a/docs/src/admin/docker.md
+++ b/docs/src/admin/docker.md
@@ -31,10 +31,30 @@ To run Gutenberg using the prebuilt Docker images, you need to download the `com
 mkdir gutenberg && cd gutenberg
 
 # Download compose.yml
-curl -O [https://raw.githubusercontent.com/KSIUJ/gutenberg/main/compose.yml](https://raw.githubusercontent.com/KSIUJ/gutenberg/main/compose.yml)
+curl -O https://raw.githubusercontent.com/KSIUJ/gutenberg/main/compose.yml
 
 # Download and rename the settings template
-curl -o docker_settings.py [https://raw.githubusercontent.com/KSIUJ/gutenberg/main/backend/gutenberg/settings/docker_settings.py.example](https://raw.githubusercontent.com/KSIUJ/gutenberg/main/backend/gutenberg/settings/docker_settings.py.example)
+curl -o docker_settings.py https://raw.githubusercontent.com/KSIUJ/gutenberg/main/backend/gutenberg/settings/docker_settings.py.example
+```
+In `docker_settings.py`, fill in the following fields properly:
+* `ALLOWED_HOSTS` - list of hosts that can connect to the app
+* `CSRF_TRUSTED_ORIGINS` - list of trusted origins for CSRF protection
+
+In addition, the value of `SECRET_KEY` will by default be read from the Docker secret
+`gutenberg_django_secret_key`. It should be set to a unique random string.
+An example of how to generate one can be found below in the [compose.yml](#composeyml) section.
+
+For example:
+```python
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
+CSRF_TRUSTED_ORIGINS = [
+    'http://127.0.0.1:3000',
+    'http://localhost:3000',
+]
+```
+After saving the file, you can run all the containers with:
+```bash
+docker compose up -d
 ```
 
 ## compose.yml

--- a/docs/src/admin/docker.md
+++ b/docs/src/admin/docker.md
@@ -54,7 +54,7 @@ CSRF_TRUSTED_ORIGINS = [
 ```
 After saving the file, you can run all the containers with:
 ```bash
-docker compose up -d
+docker compose up
 ```
 
 ## compose.yml

--- a/docs/src/admin/docker.md
+++ b/docs/src/admin/docker.md
@@ -25,34 +25,21 @@ In summary:
 | `gutenberg-proxy`    | Nginx for routing requests                       |
 
 ## Configuration
-To run Gutenberg in Docker, you need to create your own version of the settings:
+To run Gutenberg using the prebuilt Docker images, you need to download the `compose.yml` file and the example settings file. Place them in a new directory on your server:
+
 ```bash
-  cp backend/gutenberg/settings/docker_settings.py.example backend/gutenberg/settings/docker_settings.py
-```
-In `docker_settings.py`, fill in the following fields properly:
-* `ALLOWED_HOSTS` - list of hosts that can connect to the app
-* `CSRF_TRUSTED_ORIGINS` - list of trusted origins for CSRF protection
+mkdir gutenberg && cd gutenberg
 
-In addition, the value of `SECRET_KEY` will by default be read from the Docker secret
-`gutenberg_django_secret_key`. It should be set to a unique random string.
-An example of how to generate one can be found below in the [docker-compose.yml](#docker-composeyml) section.
+# Download compose.yml
+curl -O [https://raw.githubusercontent.com/KSIUJ/gutenberg/main/compose.yml](https://raw.githubusercontent.com/KSIUJ/gutenberg/main/compose.yml)
 
-For example:
-```python
-ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
-CSRF_TRUSTED_ORIGINS = [
-    'http://127.0.0.1:3000',
-    'http://localhost:3000',
-]
-```
-After saving the file, you can run all the containers with:
-```bash
-docker compose up --build	
+# Download and rename the settings template
+curl -o docker_settings.py [https://raw.githubusercontent.com/KSIUJ/gutenberg/main/backend/gutenberg/settings/docker_settings.py.example](https://raw.githubusercontent.com/KSIUJ/gutenberg/main/backend/gutenberg/settings/docker_settings.py.example)
 ```
 
-## docker-compose.yml
-The `docker-compose.yml` file provides an example Docker Compose configuration, which references the local `Dockerfile`
-to build the required Docker images. You might need to modify it to fit your deployment.
+## compose.yml
+
+The `compose.yml` file provides an example Docker Compose configuration, which uses the published Docker images. You might need to modify it to fit your deployment.
 
 Two secrets need to be provided for Docker Compose: `gutenberg_postgres_password` and
 `gutenberg_django_secret_key`. They should be randomly generated strings and should be kept secret.
@@ -177,7 +164,7 @@ It will be used as the `-f` argument to commands provided by `cups-client`
 
 To use the CUPS server running on the host machine, you can mount the
 `/run/cups` directory from the host machine to the Docker containers for
-the backend and the Celery worker. The example `docker-compose.yml` file
+the backend and the Celery worker. The example `compose.yml` file
 does this. The `CUPS_SERVERNAME` can then be set to `/run/cups/cups.sock`.
 
 > [!WARNING]

--- a/docs/src/internals/docker.md
+++ b/docs/src/internals/docker.md
@@ -6,10 +6,8 @@ All build targets are described in comments in the Dockerfile itself.
 The graph below visualizes the build-time layer dependencies.
 
 The images are based on Alpine Linux or on Debian. The variables `DEBIAN_VER` and `ALPINE_VER`
-are used to select versions of the base images. The same versions should albo be used
-when specifying image versions in `docker-compose.yml`. Using common versions let's
-Docker reduce the disk space used by the images.
-
+are used to select versions of the base images. The same versions should albo be used 
+when specifying image versions in `compose.yml`. Using common versions let's Docker reduce the disk space used by the images.
 ## Targets in Dockerfile
 - A solid line from `a` to `b` represents the `FROM a AS b` instruction.
 - A dashed line from `a` to `b` represents `COPY --from a` as a layer of target `b`. 

--- a/docs/src/internals/docker.md
+++ b/docs/src/internals/docker.md
@@ -85,6 +85,6 @@ Gutenberg uses GitHub Actions (`docker-publish.yml`) to automatically build and 
 The images are built automatically on every push to the `main` and `develop` branches, as well as whenever a new GitHub Release is published.
 The workflow uses the `docker/metadata-action` to dynamically generate tags. Images are tagged with the branch name (for example, `main`, `develop`) for branch pushes. For releases, they are tagged using Semantic Versioning (SemVer) based on the release tag.
 We do not publish images with a `latest` tag.
-Pproduction deployments should
+Production deployments should
 rely on explicit release tags (like `v1.2.3`), a `latest` tag could break deployments when a new  major version of Gutenberg is released.   
 The `main` and `develop` tags reflect the latest state of those respective branches.

--- a/docs/src/internals/docker.md
+++ b/docs/src/internals/docker.md
@@ -84,4 +84,7 @@ See the `ENV DJANGO_SETTINGS_MODULE=` commands in the `Dockerfile`.
 Gutenberg uses GitHub Actions (`docker-publish.yml`) to automatically build and publish Docker images to the GitHub Container Registry (GHCR).
 The images are built automatically on every push to the `main` and `develop` branches, as well as whenever a new GitHub Release is published.
 The workflow uses the `docker/metadata-action` to dynamically generate tags. Images are tagged with the branch name (for example, `main`, `develop`) for branch pushes. For releases, they are tagged using Semantic Versioning (SemVer) based on the release tag.
-By default, we avoid using a generic `latest` tag to prevent unpredictable updates. Production deployments should rely on explicit release tags (like `v1.2.3`), while `main` and `develop` tags reflect the latest state of those respective branches.
+We do not publish images with a `latest` tag.
+Pproduction deployments should
+rely on explicit release tags (like `v1.2.3`), a `latest` tag could break deployments when a new  major version of Gutenberg is released.   
+The `main` and `develop` tags reflect the latest state of those respective branches.

--- a/docs/src/internals/docker.md
+++ b/docs/src/internals/docker.md
@@ -78,3 +78,10 @@ from `/app/backend/gutenberg/settings/docker_settings.py`.
 Build-time steps (like running the `collectstatic` command) use `docker_base.py` as the settings module.
 Run-time commands (starting the Django server and Celery worker) use `docker_server_overrides.py`.
 See the `ENV DJANGO_SETTINGS_MODULE=` commands in the `Dockerfile`.
+
+
+## Automatic Image Publishing
+Gutenberg uses GitHub Actions (`docker-publish.yml`) to automatically build and publish Docker images to the GitHub Container Registry (GHCR).
+The images are built automatically on every push to the `main` and `develop` branches, as well as whenever a new GitHub Release is published.
+The workflow uses the `docker/metadata-action` to dynamically generate tags. Images are tagged with the branch name (for example, `main`, `develop`) for branch pushes. For releases, they are tagged using Semantic Versioning (SemVer) based on the release tag.
+By default, we avoid using a generic `latest` tag to prevent unpredictable updates. Production deployments should rely on explicit release tags (like `v1.2.3`), while `main` and `develop` tags reflect the latest state of those respective branches.

--- a/docs/src/internals/docker.md
+++ b/docs/src/internals/docker.md
@@ -7,7 +7,7 @@ The graph below visualizes the build-time layer dependencies.
 
 The images are based on Alpine Linux or on Debian. The variables `DEBIAN_VER` and `ALPINE_VER`
 are used to select versions of the base images. The same versions should albo be used 
-when specifying image versions in `compose.yml`. Using common versions let's Docker reduce the disk space used by the images.
+when specifying image versions in `compose.yml`. Using common versions lets Docker reduce the disk space used by the images.
 ## Targets in Dockerfile
 - A solid line from `a` to `b` represents the `FROM a AS b` instruction.
 - A dashed line from `a` to `b` represents `COPY --from a` as a layer of target `b`. 


### PR DESCRIPTION
Closes #184

This pull request implements the requested CI/CD pipeline for Docker images and simplifies the setup process for end-users.

Changes:
- Added a new workflow (`docker-publish.yml`) to automatically build and publish `backend`, `celery`, and `proxy` images to the GitHub Container Registry
- Removed the legacy `docker-compose.yml` and introduced a new `compose.yml` that pulls the prebuilt images from GHCR instead of building them from source
- Decided that users will place `docker_settings.py` next to the `compose.yml` file. Updated the `ImportError` message in `docker_server_overrides.py` to reflect this
- Updated `docs/docker.md` and internal docs. Added instructions for users to fetch the required setup files (`compose.yml` and `docker_settings.py.example`) directly from the repository using `curl`